### PR TITLE
Add TIMM Bakcbone

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ torch>=2.0.0
 torchvision>=0.15.0
 lightning>=2.0.0
 torchmetrics>=0.11.4
+timm>=0.9.5
 
 # --------- hydra --------- #
 hydra-core==1.3.2

--- a/src/models/backbones/timm_model.py
+++ b/src/models/backbones/timm_model.py
@@ -8,8 +8,8 @@ import torch.nn as nn
 class TimmBackbone(nn.Module):
     def __init__(self, model_name: str, pretrained: bool, features_only=False, **kwargs) -> None:
         self.model = timm.create_model(
-            model_name, pretrained=pretrained,
-            features_only=features_only, **kwargs)
+            model_name, pretrained=pretrained, features_only=features_only, **kwargs
+        )
 
     def forward(self, x: torch.Tensor) -> Union[torch.Tensor, List[torch.Tensor]]:
         """Forward computation."""

--- a/src/models/backbones/timm_model.py
+++ b/src/models/backbones/timm_model.py
@@ -1,0 +1,16 @@
+from typing import List, Union
+
+import timm
+import torch
+import torch.nn as nn
+
+
+class TimmBackbone(nn.Module):
+    def __init__(self, model_name: str, pretrained: bool, features_only=False, **kwargs) -> None:
+        self.model = timm.create_model(
+            model_name, pretrained=pretrained,
+            features_only=features_only, **kwargs)
+
+    def forward(self, x: torch.Tensor) -> Union[torch.Tensor, List[torch.Tensor]]:
+        """Forward computation."""
+        return self.model(x)

--- a/tests/test_timm_model.py
+++ b/tests/test_timm_model.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+import numpy as np
+from src.models.backbones.timm_model import TimmBackbone
+
+DEVICE = torch.device('cpu')
+if torch.cuda.is_available():
+    DEVICE = torch.device('cuda')
+
+
+@pytest.mark.parametrize('batch_size,input_shape',
+                         [(2, [256, 256]), (4, [384, 384]), (2, [640, 640])])
+def test_timm_backbone(batch_size,input_shape):
+
+    input_shape = np.array(input_shape)
+    x = torch.rand(batch_size, 3, *input_shape.tolist(), device=DEVICE)
+
+    model = TimmBackbone(
+        model_name='repvit_m1',
+        pretrained=True
+    )
+    model.to(DEVICE)
+
+    output = model(x)
+
+    # Check training output
+    assert output.shape == (batch_size, model.num_classes)
+
+
+@pytest.mark.parametrize('batch_size,input_shape',
+                         [(2, [256, 256]), (4, [384, 384]), (2, [640, 640])])
+def test_timm_backbone_features(batch_size,input_shape):
+
+    input_shape = np.array(input_shape)
+    x = torch.rand(batch_size, 3, *input_shape.tolist(), device=DEVICE)
+
+    model = TimmBackbone(
+        model_name='repvit_m1',
+        pretrained=True,
+        features_only=True,
+        out_indicies=(1,2,3,4)
+    )
+    model.to(DEVICE)
+
+    output = model(x)
+
+    # Check training output
+    assert len(output) == 4
+    for i, o in enumerate(output):
+        assert list(o.shape[2:]) == list(input_shape//(2**(i+2)))

--- a/tests/test_timm_model.py
+++ b/tests/test_timm_model.py
@@ -1,24 +1,22 @@
+import numpy as np
 import pytest
 import torch
-import numpy as np
+
 from src.models.backbones.timm_model import TimmBackbone
 
-DEVICE = torch.device('cpu')
+DEVICE = torch.device("cpu")
 if torch.cuda.is_available():
-    DEVICE = torch.device('cuda')
+    DEVICE = torch.device("cuda")
 
 
-@pytest.mark.parametrize('batch_size,input_shape',
-                         [(2, [256, 256]), (4, [384, 384]), (2, [640, 640])])
-def test_timm_backbone(batch_size,input_shape):
-
+@pytest.mark.parametrize(
+    "batch_size,input_shape", [(2, [256, 256]), (4, [384, 384]), (2, [640, 640])]
+)
+def test_timm_backbone(batch_size, input_shape):
     input_shape = np.array(input_shape)
     x = torch.rand(batch_size, 3, *input_shape.tolist(), device=DEVICE)
 
-    model = TimmBackbone(
-        model_name='repvit_m1',
-        pretrained=True
-    )
+    model = TimmBackbone(model_name="repvit_m1", pretrained=True)
     model.to(DEVICE)
 
     output = model(x)
@@ -27,18 +25,15 @@ def test_timm_backbone(batch_size,input_shape):
     assert output.shape == (batch_size, model.num_classes)
 
 
-@pytest.mark.parametrize('batch_size,input_shape',
-                         [(2, [256, 256]), (4, [384, 384]), (2, [640, 640])])
-def test_timm_backbone_features(batch_size,input_shape):
-
+@pytest.mark.parametrize(
+    "batch_size,input_shape", [(2, [256, 256]), (4, [384, 384]), (2, [640, 640])]
+)
+def test_timm_backbone_features(batch_size, input_shape):
     input_shape = np.array(input_shape)
     x = torch.rand(batch_size, 3, *input_shape.tolist(), device=DEVICE)
 
     model = TimmBackbone(
-        model_name='repvit_m1',
-        pretrained=True,
-        features_only=True,
-        out_indicies=(1,2,3,4)
+        model_name="repvit_m1", pretrained=True, features_only=True, out_indicies=(1, 2, 3, 4)
     )
     model.to(DEVICE)
 
@@ -47,4 +42,4 @@ def test_timm_backbone_features(batch_size,input_shape):
     # Check training output
     assert len(output) == 4
     for i, o in enumerate(output):
-        assert list(o.shape[2:]) == list(input_shape//(2**(i+2)))
+        assert list(o.shape[2:]) == list(input_shape // (2 ** (i + 2)))


### PR DESCRIPTION
Add Torch Image Models (TIMM) as modular backbone type for `RepViT`, `MobileViT`, or `MobileOne`.

Solve #2 